### PR TITLE
Add error_message field to tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+OpsBlade is an Ansible-inspired cloud operations tool written in Go. It executes tasks sequentially from YAML configuration files, designed for AWS, Jira, and Slack operations automation.
+
+## Development Commands
+
+### Build
+```bash
+# Standard build
+go build -o opsblade
+
+# Build without CGO dependencies (for portability)
+CGO_ENABLED=0 go build -o opsblade
+
+# Cross-compilation
+GOOS=linux GOARCH=amd64 go build -o opsblade-linux
+```
+
+### Test
+```bash
+# Run all tests
+go test ./...
+
+# Run tests in a specific package
+go test ./shared/
+
+# Run with verbose output
+go test -v ./...
+```
+
+### Run
+```bash
+# Execute a workflow from file
+./opsblade workflow.yaml
+
+# Execute with flags
+./opsblade -d workflow.yaml  # Dry run mode
+./opsblade -v workflow.yaml  # Debug mode
+./opsblade -j workflow.yaml  # JSON output
+./opsblade -s < workflow.yaml  # Read from stdin
+```
+
+## Architecture
+
+### Core Structure
+
+The project follows a modular task-based architecture:
+
+1. **Main Entry Point** (`main.go`): CLI interface that loads and executes workflows
+2. **Workflow Engine** (`workflow/workflow.go`): Orchestrates task execution from YAML configurations
+3. **Task System**: Each operation is implemented as a self-registering task module
+
+### Task Registration Pattern
+
+Tasks self-register via `init()` functions when imported in `workflow/workflow.go`. Each task:
+- Implements the `shared.Task` interface with an `Execute()` method
+- Registers itself with `shared.RegisterTask(taskID, constructor)`
+- Deserializes its own configuration from `Context.Instructions`
+
+### Key Components
+
+- **services/**: Cloud service clients (AWS, Jira, Slack)
+  - `cloudaws/`: AWS SDK wrappers for EC2, ASG operations
+  - `cloudjira/`: Jira API client for issue management
+  - `cloudslack/`: Slack webhook integration
+  
+- **shared/**: Common utilities and interfaces
+  - `TaskContext`: Core task execution context
+  - `TaskResult`: Standardized result handling
+  - Variable resolution system (`{{var_name}}` syntax)
+  - Field filtering and selection utilities
+
+- **workflow/**: Task implementations organized by service
+  - `aws/`: EC2, ASG, AMI management tasks
+  - `jira/`: Issue creation, commenting, attachments
+  - `slack/`: Message sending
+  - `variables/`: Variable management (set, save, load)
+  - `misc/`: Utility tasks (sleep, dryrun, exitIf)
+
+### Configuration Flow
+
+1. Global settings (dryrun, debug, json, env) loaded from YAML
+2. Task-specific environment files override global settings
+3. Variables resolved using `{{variable_name}}` syntax
+4. Filters, select criteria, and field selections applied to API results
+
+### Credential Management
+
+Credentials are loaded from environment files (.env format), never from YAML:
+- AWS: Uses SDK default chain or AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
+- Jira: Requires JIRA_USER, JIRA_TOKEN, JIRA_URL
+- Slack: Uses SLACK_WEBHOOK (with optional env_suffix for multiple channels)
+
+## Adding New Tasks
+
+1. Create a new package under `workflow/[service]/[operation]/`
+2. Implement the task struct with `Context shared.TaskContext`
+3. Add an `init()` function to register the task
+4. Implement `Execute()` method returning `shared.TaskResult`
+5. Import the package in `workflow/workflow.go` using underscore import
+
+Example structure from `workflow/example/example.go` provides a complete template.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ And like most programs written in Go, cross-compilation using GOOS and GOARCH is
 
 The yaml file consists of some global settings and a list of tasks. The task `name` is arbitrary and are intended for human use only. The `task` field is matched against the task registry and therefore must match a task identifier of an included module from workflow/. If the task identifier is not found, a fatal error occurs.
 
+### Task Fields
+
+Each task in the YAML file can include the following common fields:
+
+* `name`: Human-readable task name (optional)
+* `task`: Task identifier that must match a registered task type (required)
+* `skip`: Boolean to skip task execution (optional, default: false)
+* `error_message`: Custom message to display when the task fails (optional, available in v0.1.11+)
+* `env`: Task-specific environment file (optional, overrides global env)
+
+The `error_message` field is particularly useful for providing context when expected failures occur. For example:
+
+```yaml
+- name: Load staging deployment results
+  task: variables_load
+  filename: "/home/eric/data/pending.json"
+  error_message: "This is normal when the previous deployment succeeds. The file is created only when there are pending tasks."
+```
+
 The following environment variables are supported:
 
 ### AWS

--- a/example.yaml.txt
+++ b/example.yaml.txt
@@ -40,6 +40,14 @@ tasks:
       - id
       - tags.tag1
 
+  # Example of loading variables with a custom error message (v0.1.11+)
+  # The error_message field provides context when a task fails, useful for expected failures
+  - name: "Load previous run results"
+    task: "variables_load"
+    filename: "/tmp/previous_run.json"
+    error_message: "This is expected if this is the first run. The file is created after the first successful execution."
+    skip: true  # Set to false to actually run this task
+
   # The save task is completely optional and allows filtering.
   # A common use case would be to store the output from a task for later processing. The file saved
   # with variables_saved can be loaded in another workflow with variables_load.

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 //goland:noinspection GoUnusedConst
 const (
 	PROGNAME = "OpsBlade"
-	VERSION  = "0.1.10"
+	VERSION  = "0.1.11"
 )
 
 // This program serves both as a CLI to execute workflows from a YAML file or stdin, and as an example of

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -190,9 +190,15 @@ func (w *Workflow) Execute() bool {
 			skip = false
 		}
 
+		errorMessage, ok := rawTask["error_message"].(string)
+		if !ok {
+			errorMessage = ""
+		}
+
 		taskContext.Name = taskName
 		taskContext.Task = taskType
 		taskContext.Sequence = count
+		taskContext.ErrorMessage = errorMessage
 
 		if taskType == "" {
 			if w.taskEnd(taskContext.Error(fmt.Sprintf("%s: Task type is missing or not a string\n", taskContext.String()), nil)) {


### PR DESCRIPTION
This allows clarity when errors are expected to occur as a normal part of the workflow. If present, the contents of the optional error_message field will be displayed.